### PR TITLE
Refine frontend layout with reusable list component

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,38 @@
-from flask import Flask, send_from_directory, jsonify
+from flask import Flask, send_from_directory, jsonify, request
 import pandas as pd
-from models import hybrid_npr  # Make sure this is in models.py
+from models import hybrid_npr, HybridContent
 import os
+import requests
 
 # Load data
 anime_df_clean = pd.read_pickle("anime_df_final.pk")
 rating_df_clean = pd.read_pickle("rating_df_final.pk")
 
 app = Flask(__name__, static_folder='frontend/build', static_url_path='')
+
+# Simple in-memory cache for poster URLs
+_poster_cache = {}
+
+def fetch_poster(anime_id):
+    """Retrieve poster image from Jikan API and cache the result."""
+    if anime_id in _poster_cache:
+        return _poster_cache[anime_id]
+    try:
+        resp = requests.get(
+            f"https://api.jikan.moe/v4/anime/{anime_id}", timeout=5,
+            headers={"User-Agent": "anime-recommender"}
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            url = data.get("data", {}).get("images", {}).get("jpg", {}).get("image_url", "")
+        else:
+            url = ""
+    except Exception:
+        url = ""
+    if not url:
+        url = "https://via.placeholder.com/150x210?text=No+Image"
+    _poster_cache[anime_id] = url
+    return url
 
 @app.route('/')
 def serve():
@@ -16,7 +41,41 @@ def serve():
 @app.route('/api/top-anime', methods=['GET'])
 def get_top_anime():
     top_recs = hybrid_npr(rating_df_clean, anime_df_clean)
-    return jsonify(top_recs.to_dict(orient='records'))
+    records = top_recs.to_dict(orient='records')
+    for rec in records:
+        rec['image_url'] = fetch_poster(rec['anime_id'])
+    return jsonify(records)
+
+
+@app.route('/api/recommend', methods=['GET'])
+def recommend():
+    """Return recommendations based on a provided anime title."""
+    title = request.args.get('title', '')
+    if not title:
+        return jsonify([])
+    try:
+        recs = HybridContent(title, anime_df_clean)
+    except Exception:
+        return jsonify([])
+
+    # recs may be a Series of anime names
+    if hasattr(recs, 'to_frame'):
+        recs = recs.to_frame(name='anime_name')
+    if 'anime_name' not in recs.columns:
+        recs = recs.rename(columns={recs.columns[0]: 'anime_name'})
+
+    result = []
+    for name in recs['anime_name']:
+        row = anime_df_clean.loc[anime_df_clean['anime_name'] == name]
+        if row.empty:
+            continue
+        aid = int(row.iloc[0]['anime_id'])
+        result.append({
+            'anime_name': name,
+            'anime_id': aid,
+            'image_url': fetch_poster(aid)
+        })
+    return jsonify(result)
 
 @app.errorhandler(404)
 def not_found(e):

--- a/frontend/src/AnimeList.js
+++ b/frontend/src/AnimeList.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+function AnimeList({ title, list }) {
+  if (!list || list.length === 0) {
+    return null;
+  }
+
+  return (
+    <section>
+      {title && <h2>{title}</h2>}
+      <ul className="anime-list">
+        {list.map((anime, idx) => (
+          <li key={anime.anime_id}>
+            <span className="rank">#{idx + 1}</span>
+            <img
+              className="poster"
+              src={anime.image_url || 'https://via.placeholder.com/150x210?text=No+Image'}
+              alt={anime.anime_name}
+              loading="lazy"
+            />
+            {anime.anime_name}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default AnimeList;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -16,7 +16,7 @@ h1 {
   list-style: none;
   padding: 0;
   margin: 2rem auto;
-  max-width: 600px;
+  max-width: 800px;
 }
 
 .anime-list li {
@@ -34,4 +34,42 @@ h1 {
   font-weight: bold;
   margin-right: 1rem;
   color: #00d8ff;
+}
+
+.poster {
+  width: 150px;
+  height: 210px;
+  object-fit: cover;
+  margin-right: 1rem;
+  border-radius: 4px;
+}
+
+.search {
+  margin-top: 1rem;
+}
+
+.search input {
+  padding: 0.5rem;
+  width: 200px;
+  border-radius: 4px;
+  border: none;
+  margin-right: 0.5rem;
+}
+
+.search button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: #00d8ff;
+  color: #1e1e1e;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.search button:hover {
+  background: #00b0cc;
+}
+
+.no-results {
+  margin-top: 1rem;
+  color: #ff8080;
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,31 +1,52 @@
 import React, { useEffect, useState } from 'react';
 import './App.css';
+import AnimeList from './AnimeList';
 
 function App() {
   const [recommendations, setRecommendations] = useState([]);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
 
   useEffect(() => {
     fetch('/api/top-anime')
       .then(res => res.json())
       .then(data => setRecommendations(data))
-      .catch(err => console.error("Failed to fetch recommendations", err));
+      .catch(err => console.error('Failed to fetch recommendations', err));
   }, []);
+
+  const handleSearch = (e) => {
+    e.preventDefault();
+    if (!query.trim()) return;
+    fetch(`/api/recommend?title=${encodeURIComponent(query)}`)
+      .then(res => res.json())
+      .then(data => setResults(data))
+      .catch(err => console.error('Failed to fetch search', err));
+  };
 
   return (
     <div className="App">
       <header>
-        <h1>Top Anime Recommendations</h1>
-        <p>These are the most popular and highest rated anime according to our model.</p>
+        <h1>Anime Recommendations</h1>
+        <form className="search" onSubmit={handleSearch}>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search anime title"
+          />
+          <button type="submit">Search</button>
+        </form>
       </header>
 
       <main>
-        <ul className="anime-list">
-          {recommendations.map((anime, index) => (
-            <li key={anime.anime_id}>
-              <span className="rank">#{index + 1}</span> {anime.anime_name}
-            </li>
-          ))}
-        </ul>
+        {results.length > 0 && (
+          <AnimeList title={`Results for "${query}"`} list={results} />
+        )}
+        {query && results.length === 0 && (
+          <p className="no-results">No results found.</p>
+        )}
+
+        <AnimeList title="Top Anime" list={recommendations} />
       </main>
     </div>
   );

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = screen.getByText(/Anime Recommendations/i);
+  expect(header).toBeInTheDocument();
 });

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pandas
 numpy
 scikit-learn
 # plus any library used in models.py
+requests
+# plus any library used in models.py


### PR DESCRIPTION
## Summary
- switch to reusable `AnimeList` component
- enlarge posters and placeholder images
- show message when search returns no results

## Testing
- `npm test --prefix frontend -- --watchAll=false`
- `python3 -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_683fe7313ad8832fb9964d725dd682f0